### PR TITLE
[modify] countCommentsByTripId 함수 재정의

### DIFF
--- a/src/main/kotlin/kr/kro/tripsketch/repositories/CommentRepository.kt
+++ b/src/main/kotlin/kr/kro/tripsketch/repositories/CommentRepository.kt
@@ -13,6 +13,5 @@ interface CommentRepository : MongoRepository<Comment, String> {
     // 특정 부모 댓글에 속한 모든 자식 댓글 검색
     fun findAllByParentId(parentId: String): List<Comment>
 
-    @Query("{'tripId': ?0}")
-    fun countCommentsByTripId(tripId: String): Int? = 0
+    fun countCommentsByTripId(tripId: String): Int
 }


### PR DESCRIPTION
Caused by: org.springframework.data.mapping.MappingException: Expected to read Document Document{{_id=65074f1d9cb0e221480c0682, userId=64fea3dbbc97ef133d7e59dc, tripId=6506ef7946b63664e4ec26b5, content=홍도 잼나여?, createdAt=Mon Sep 18 04:10:21 KST 2023, updatedAt=Mon Sep 18 04:10:21 KST 2023, likedBy=[], children=[], isDeleted=false, isLiked=false, numberOfLikes=0, _class=kr.kro.tripsketch.domain.Comment}} into type class java.lang.Integer but didn't find a PersistentEntity for the latter 문제 해결을 위해

countCommentsByTripId 함수 재정의